### PR TITLE
Add CI workflow and Docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          pip install -r gct-market-sentiment/requirements.txt
+          pip install pip-audit
+      - name: Python formatting check
+        run: black --check gct-market-sentiment
+      - name: Security audit for Python deps
+        run: pip-audit -r gct-market-sentiment/requirements.txt
+      - name: Run Python tests
+        working-directory: gct-market-sentiment
+        run: pytest -q
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install Node dependencies
+        working-directory: soulmath-moderation-system
+        run: npm ci
+      - name: Run Node tests
+        working-directory: soulmath-moderation-system
+        run: npm test -- --watchAll=false
+      - name: Build React app
+        working-directory: soulmath-moderation-system
+        run: npm run build
+      - name: Security audit for Node deps
+        working-directory: soulmath-moderation-system
+        run: npm audit --audit-level=high || true

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Both the market sentiment engine and moderation backend expose OpenAPI-compliant
 endpoints. When running either service locally, navigate to `/docs` to view
 interactive Swagger documentation or `/openapi.json` for the raw specification.
 
+## 🛠 CI/CD & Containers
+
+Automated GitHub Actions run on each commit to format the code, audit dependencies,
+and execute tests for both projects. Dockerfiles are provided so each service can
+be built and run consistently across environments. Use `docker-compose up` to
+launch the market sentiment dashboard on port `8501` and the moderation
+dashboard on port `3000`.
+
 ## 🤝 Contributing
 
 We welcome contributions to GCT implementations! Please:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  sentiment:
+    build: ./gct-market-sentiment
+    ports:
+      - "8501:8501"
+  moderation:
+    build: ./soulmath-moderation-system
+    ports:
+      - "3000:3000"

--- a/gct-market-sentiment/Dockerfile
+++ b/gct-market-sentiment/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["streamlit", "run", "app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/soulmath-moderation-system/Dockerfile
+++ b/soulmath-moderation-system/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- configure GitHub Actions CI pipeline
- add Dockerfiles for the Python and React projects
- provide docker-compose orchestration
- document CI/CD and container usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test -- --watchAll=false` *(fails: Jest encountered unexpected token)*
- `npm run build` *(fails: TS2345 Argument type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68731913fb3483218e220219ee566757