### PR TITLE
fix: Resolve CI workflow conflict - separate Python and Node jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,46 +6,62 @@ on:
   pull_request:
 
 jobs:
-  test:
+  python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+      
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          
       - name: Install Python dependencies
         run: |
           pip install -r gct-market-sentiment/requirements-dev.txt
+          
       - name: Python formatting check
         run: black --check gct-market-sentiment
+        
       - name: Python lint
         run: flake8 gct-market-sentiment
+        
       - name: Security audit for Python deps
         run: pip-audit -r gct-market-sentiment/requirements.txt
+        
       - name: Static analysis
         run: bandit -r gct-market-sentiment -ll
+        
       - name: Run Python tests
         working-directory: gct-market-sentiment
         run: pytest -q
 
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
+          
       - name: Install Node dependencies
         working-directory: soulmath-moderation-system
         run: npm ci
+        
       - name: Run ESLint
         working-directory: soulmath-moderation-system
         run: npm run lint
+        
       - name: Run Node tests
         working-directory: soulmath-moderation-system
-        run: npm test -- --watchAll=false
+        run: CI=true npm test -- --watchAll=false
+        
       - name: Build React app
         working-directory: soulmath-moderation-system
         run: npm run build
+        
       - name: Security audit for Node deps
         working-directory: soulmath-moderation-system
         run: npm audit --audit-level=high || true


### PR DESCRIPTION
- Split CI into separate Python and Node.js jobs for parallel execution
- Use Node.js 20 (latest LTS) instead of 18
- Keep all testing, linting, and security checks from both versions
- Maintain requirements-dev.txt for Python dependencies
- Add CI=true environment variable for React tests

This ensures both Python and Node.js components are properly tested independently.

🤖 Generated with [Claude Code](https://claude.ai/code)