### PR TITLE
Add playlist engine skeleton

### DIFF
--- a/gct-playlist-engine/README.md
+++ b/gct-playlist-engine/README.md
@@ -1,0 +1,8 @@
+# GCT Playlist Engine
+
+This experimental module applies Grounded Coherence Theory to music streaming.
+It contains skeleton classes for fetching audio data, extracting features, and
+optimizing playlists with coherence metrics.
+
+The implementation is intentionally lightweight and leaves external integrations
+(e.g. music catalogs, NLP models) as placeholders.

--- a/gct-playlist-engine/api_server.py
+++ b/gct-playlist-engine/api_server.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from .data_pipeline import DataPipeline
+from .feature_extractor import FeatureExtractor
+from .gct_model import GCTModel
+from .playlist_optimizer import PlaylistOptimizer
+
+app = FastAPI()
+
+@app.post("/generate-playlist")
+def generate_playlist(request: dict):
+    """Return a coherent playlist based on the request parameters."""
+    # 1. Load user profile (placeholder)
+    user_profile = {}
+
+    pipeline = DataPipeline(source_config={})
+    extractor = FeatureExtractor(audio_model=None, nlp_model=None)
+    gct_model = GCTModel()
+    optimizer = PlaylistOptimizer(gct_model, user_profile)
+
+    # TODO: fetch data, compute features, and build playlist
+    raise NotImplementedError

--- a/gct-playlist-engine/data_pipeline.py
+++ b/gct-playlist-engine/data_pipeline.py
@@ -1,0 +1,18 @@
+from typing import List, Dict
+import pandas as pd
+
+class DataPipeline:
+    """Load audio metadata and lyrics for playlist generation."""
+
+    def __init__(self, source_config: Dict):
+        self.source_config = source_config
+
+    def fetch_audio_metadata(self, track_ids: List[str]) -> pd.DataFrame:
+        """Retrieve audio features and metadata for the given track IDs."""
+        # Placeholder: integrate with actual catalog or API
+        raise NotImplementedError
+
+    def fetch_lyrics(self, track_ids: List[str]) -> Dict[str, str]:
+        """Retrieve lyrics text for semantic analysis."""
+        # Placeholder: implement lyrics retrieval
+        raise NotImplementedError

--- a/gct-playlist-engine/feature_extractor.py
+++ b/gct-playlist-engine/feature_extractor.py
@@ -1,0 +1,17 @@
+from typing import Dict
+import pandas as pd
+
+class FeatureExtractor:
+    """Extract audio and lyric features for coherence scoring."""
+
+    def __init__(self, audio_model=None, nlp_model=None):
+        self.audio_model = audio_model
+        self.nlp_model = nlp_model
+
+    def extract_audio_features(self, audio_metadata: pd.DataFrame) -> pd.DataFrame:
+        """Normalize and vectorize audio descriptors like tempo or energy."""
+        raise NotImplementedError
+
+    def extract_lyric_embeddings(self, lyrics: Dict[str, str]) -> pd.DataFrame:
+        """Convert lyrics into embedding vectors using NLP model."""
+        raise NotImplementedError

--- a/gct-playlist-engine/gct_model.py
+++ b/gct-playlist-engine/gct_model.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+class GCTModel:
+    """Compute coherence metrics for playlist transitions."""
+
+    def __init__(self, psi_weight=1.0, rho_weight=1.0, q_opt_weight=1.0, f_weight=1.0, alpha_weight=1.0):
+        self.psi_weight = psi_weight
+        self.rho_weight = rho_weight
+        self.q_opt_weight = q_opt_weight
+        self.f_weight = f_weight
+        self.alpha_weight = alpha_weight
+
+    def compute_coherence(self, features_df: pd.DataFrame) -> pd.DataFrame:
+        """Apply GCT formulas to compute coherence metrics between tracks."""
+        raise NotImplementedError

--- a/gct-playlist-engine/playlist_optimizer.py
+++ b/gct-playlist-engine/playlist_optimizer.py
@@ -1,0 +1,16 @@
+from typing import List, Tuple, Dict
+
+class PlaylistOptimizer:
+    """Generate coherent playlists using the GCT model."""
+
+    def __init__(self, gct_model, user_profile: Dict):
+        self.gct_model = gct_model
+        self.user_profile = user_profile
+
+    def score_transitions(self, track_pairs: List[Tuple[str, str]]) -> Dict[Tuple[str, str], float]:
+        """Return coherence scores for track transitions."""
+        raise NotImplementedError
+
+    def build_playlist(self, seed_track: str, length: int) -> List[str]:
+        """Construct a playlist maximizing cumulative coherence."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- introduce `gct-playlist-engine` package
- add stubs for playlist pipeline, feature extraction, and GCT coherence scoring
- include FastAPI endpoint skeleton

## Testing
- `pytest -q` *(fails: several tests error due to missing deps and async fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_6876c345e29c832194f332db93ccafd8