### PR TITLE
Fix Jest ESM issue

### DIFF
--- a/soulmath-moderation-system/.babelrc
+++ b/soulmath-moderation-system/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ]
+}

--- a/soulmath-moderation-system/jest.config.js
+++ b/soulmath-moderation-system/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  transformIgnorePatterns: ['/node_modules/(?!(axios)/)'],
+};

--- a/soulmath-moderation-system/package.json
+++ b/soulmath-moderation-system/package.json
@@ -54,6 +54,11 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "@babel/preset-env": "^7.24.1",
+    "@babel/preset-react": "^7.23.3",
+    "@babel/preset-typescript": "^7.23.3",
+    "babel-jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Babel presets for React, TS and env
- add jest config to ensure axios is transformed
- update development dependencies accordingly

## Testing
- `CI=true npm test --silent` in `soulmath-moderation-system`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6876dd5353848321bd96becfab7ab642