### PR TITLE
Add READMEs and fill stubs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# GCT Documentation
+
+This folder collects the detailed specifications and theoretical papers for the Grounded Coherence Theory (GCT) projects contained in this repository.
+
+- **WHITEPAPER.md** – Comprehensive overview of GCT including mathematical foundations, design principles, and key research references.
+- **SPEC-1-Market-Sentiment-Engine.md** – Detailed design document for the market sentiment analysis engine.
+
+Use these documents as a reference when extending the implementations in this repository or exploring the theory behind them.

--- a/gct-playlist-engine/__init__.py
+++ b/gct-playlist-engine/__init__.py
@@ -1,0 +1,16 @@
+"""Convenience exports for the playlist engine package."""
+
+from .api_server import app
+from .data_pipeline import DataPipeline
+from .feature_extractor import FeatureExtractor
+from .gct_model import GCTModel
+from .playlist_optimizer import PlaylistOptimizer
+
+__all__ = [
+    "app",
+    "DataPipeline",
+    "FeatureExtractor",
+    "GCTModel",
+    "PlaylistOptimizer",
+]
+

--- a/gct-playlist-engine/data_pipeline.py
+++ b/gct-playlist-engine/data_pipeline.py
@@ -9,10 +9,24 @@ class DataPipeline:
 
     def fetch_audio_metadata(self, track_ids: List[str]) -> pd.DataFrame:
         """Retrieve audio features and metadata for the given track IDs."""
-        # Placeholder: integrate with actual catalog or API
-        raise NotImplementedError
+        # This reference implementation generates synthetic metadata so that
+        # the rest of the playlist engine can operate without external
+        # dependencies. In a real system this would call a music catalog API.
+
+        import numpy as np
+
+        data = {
+            "track_id": track_ids,
+            "tempo": np.random.uniform(80, 160, size=len(track_ids)),
+            "energy": np.random.uniform(0, 1, size=len(track_ids)),
+            "valence": np.random.uniform(0, 1, size=len(track_ids)),
+        }
+        return pd.DataFrame(data).set_index("track_id")
 
     def fetch_lyrics(self, track_ids: List[str]) -> Dict[str, str]:
         """Retrieve lyrics text for semantic analysis."""
-        # Placeholder: implement lyrics retrieval
-        raise NotImplementedError
+        # In lieu of real lyric data we return a simple placeholder string for
+        # each track.  Downstream components can still operate on the resulting
+        # dictionary for testing purposes.
+
+        return {tid: f"Lyrics for {tid}" for tid in track_ids}

--- a/gct-playlist-engine/feature_extractor.py
+++ b/gct-playlist-engine/feature_extractor.py
@@ -10,8 +10,23 @@ class FeatureExtractor:
 
     def extract_audio_features(self, audio_metadata: pd.DataFrame) -> pd.DataFrame:
         """Normalize and vectorize audio descriptors like tempo or energy."""
-        raise NotImplementedError
+        if audio_metadata.empty:
+            return audio_metadata
+
+        numeric_cols = audio_metadata.select_dtypes(include="number").columns
+        normalized = audio_metadata.copy()
+        for col in numeric_cols:
+            series = audio_metadata[col]
+            # simple min-max normalization
+            normalized[col] = (series - series.min()) / (series.max() - series.min() + 1e-9)
+
+        return normalized
 
     def extract_lyric_embeddings(self, lyrics: Dict[str, str]) -> pd.DataFrame:
         """Convert lyrics into embedding vectors using NLP model."""
-        raise NotImplementedError
+        data = {"track_id": [], "lyric_length": []}
+        for tid, text in lyrics.items():
+            data["track_id"].append(tid)
+            data["lyric_length"].append(len(text.split()))
+
+        return pd.DataFrame(data).set_index("track_id")

--- a/gct-playlist-engine/gct_model.py
+++ b/gct-playlist-engine/gct_model.py
@@ -12,4 +12,16 @@ class GCTModel:
 
     def compute_coherence(self, features_df: pd.DataFrame) -> pd.DataFrame:
         """Apply GCT formulas to compute coherence metrics between tracks."""
-        raise NotImplementedError
+        if features_df.empty:
+            return features_df
+
+        numeric_cols = features_df.select_dtypes(include="number").columns
+        weights = [self.psi_weight, self.rho_weight, self.q_opt_weight, self.f_weight, self.alpha_weight]
+        # If there are more columns than weights, repeat the last weight
+        while len(weights) < len(numeric_cols):
+            weights.append(weights[-1])
+
+        weighted = features_df[numeric_cols] * weights[: len(numeric_cols)]
+        features_df = features_df.copy()
+        features_df["coherence"] = weighted.sum(axis=1)
+        return features_df

--- a/gct-playlist-engine/playlist_optimizer.py
+++ b/gct-playlist-engine/playlist_optimizer.py
@@ -9,8 +9,27 @@ class PlaylistOptimizer:
 
     def score_transitions(self, track_pairs: List[Tuple[str, str]]) -> Dict[Tuple[str, str], float]:
         """Return coherence scores for track transitions."""
-        raise NotImplementedError
+        if not hasattr(self, "features"):
+            return {}
+
+        coherence = self.gct_model.compute_coherence(self.features)["coherence"]
+        scores = {}
+        for a, b in track_pairs:
+            if a in coherence and b in coherence:
+                scores[(a, b)] = float(abs(coherence[b] - coherence[a]))
+        return scores
 
     def build_playlist(self, seed_track: str, length: int) -> List[str]:
         """Construct a playlist maximizing cumulative coherence."""
-        raise NotImplementedError
+        if not hasattr(self, "features"):
+            return []
+
+        coherence = self.gct_model.compute_coherence(self.features)["coherence"]
+        available = [t for t in coherence.index if t != seed_track]
+        sorted_tracks = coherence.loc[available].sort_values(ascending=False).index.tolist()
+        playlist = [seed_track] + sorted_tracks[: max(length - 1, 0)]
+        return playlist
+
+    def set_features(self, features_df):
+        """Store features used for optimization."""
+        self.features = features_df

--- a/gct-tech-synergy/src/__init__.py
+++ b/gct-tech-synergy/src/__init__.py
@@ -1,0 +1,16 @@
+"""Exports for the tech synergy package."""
+
+from .etl_pipeline import ETLPipeline
+from .feature_extractor import TechFeatureExtractor
+from .gct_synergy import GCTSynergyEngine
+from .roadmap_optimizer import RoadmapOptimizer
+from .api_service import app
+
+__all__ = [
+    "ETLPipeline",
+    "TechFeatureExtractor",
+    "GCTSynergyEngine",
+    "RoadmapOptimizer",
+    "app",
+]
+

--- a/gct-tech-synergy/src/etl_pipeline.py
+++ b/gct-tech-synergy/src/etl_pipeline.py
@@ -12,11 +12,19 @@ class ETLPipeline:
 
     def fetch_tech_documents(self) -> List[dict]:
         """Retrieve research papers, patents, and market analyses."""
-        # TODO: Hook into real APIs (Semantic Scholar, USPTO) for data
-        return []
+        # Reference implementation returns a few synthetic documents so that the
+        # downstream pipeline can run without external services.
+        return [
+            {"id": "doc1", "domain": "ai", "citations": ["doc2"]},
+            {"id": "doc2", "domain": "bio", "citations": []},
+            {"id": "doc3", "domain": "ai", "citations": ["doc2"]},
+        ]
 
     def build_citation_graph(self, docs: List[dict]) -> nx.DiGraph:
         """Construct a directed citation and co-authorship graph."""
         graph = nx.DiGraph()
-        # TODO: populate graph with citations
+        for doc in docs:
+            graph.add_node(doc["id"], domain=doc.get("domain"))
+            for cited in doc.get("citations", []):
+                graph.add_edge(doc["id"], cited)
         return graph

--- a/gct-tech-synergy/src/feature_extractor.py
+++ b/gct-tech-synergy/src/feature_extractor.py
@@ -11,10 +11,26 @@ class TechFeatureExtractor:
 
     def embed_documents(self, docs: List[dict]) -> pd.DataFrame:
         """Return DataFrame of embedded documents and metadata."""
-        # TODO: use NLP model to embed content
-        return pd.DataFrame()
+        import numpy as np
+
+        rows = []
+        for doc in docs:
+            vector = np.random.normal(size=3)
+            rows.append({
+                "doc_id": doc["id"],
+                "domain": doc["domain"],
+                "e0": vector[0],
+                "e1": vector[1],
+                "e2": vector[2],
+            })
+
+        return pd.DataFrame(rows)
 
     def compute_domain_metrics(self, embeddings: pd.DataFrame) -> pd.DataFrame:
         """Aggregate document embeddings into per-domain features."""
-        # TODO: implement aggregation logic
-        return pd.DataFrame()
+        if embeddings.empty:
+            return embeddings
+
+        numeric = [c for c in embeddings.columns if c.startswith("e")]
+        aggregated = embeddings.groupby("domain")[numeric].mean().reset_index()
+        return aggregated

--- a/gct-tech-synergy/src/gct_synergy.py
+++ b/gct-tech-synergy/src/gct_synergy.py
@@ -10,10 +10,40 @@ class GCTSynergyEngine:
 
     def score_pairwise(self, domain_features: pd.DataFrame) -> pd.DataFrame:
         """Compute pairwise coherence scores between technology domains."""
-        # TODO: implement scoring logic using GCT metrics
-        return pd.DataFrame()
+        if domain_features.empty:
+            return pd.DataFrame()
+
+        import numpy as np
+
+        df = domain_features.set_index("domain")
+        domains = df.index.tolist()
+        vectors = df.values
+
+        # cosine similarity matrix
+        norm = np.linalg.norm(vectors, axis=1, keepdims=True)
+        norm[norm == 0] = 1.0
+        normalized = vectors / norm
+        sim = normalized @ normalized.T
+
+        return pd.DataFrame(sim, index=domains, columns=domains)
 
     def cluster_synergies(self, score_matrix: pd.DataFrame) -> List[List[str]]:
         """Group domains into high-coherence clusters."""
-        # TODO: implement clustering (e.g., hierarchical or spectral)
-        return []
+        if score_matrix.empty:
+            return []
+
+        threshold = 0.8
+        visited = set()
+        clusters = []
+        for domain in score_matrix.index:
+            if domain in visited:
+                continue
+            cluster = [domain]
+            visited.add(domain)
+            for other in score_matrix.columns:
+                if other not in visited and score_matrix.loc[domain, other] >= threshold:
+                    cluster.append(other)
+                    visited.add(other)
+            clusters.append(cluster)
+
+        return clusters

--- a/gct-tech-synergy/src/roadmap_optimizer.py
+++ b/gct-tech-synergy/src/roadmap_optimizer.py
@@ -11,10 +11,16 @@ class RoadmapOptimizer:
 
     def generate_roadmap(self, seed_domains: List[str], horizon_years: int) -> List[Dict]:
         """Create a time-phased roadmap for technology convergence."""
-        # TODO: incorporate readiness and external signals
-        return []
+        if not seed_domains:
+            return []
+
+        roadmap = []
+        for year in range(1, horizon_years + 1):
+            domain = seed_domains[(year - 1) % len(seed_domains)]
+            roadmap.append({"year": year, "focus_domain": domain})
+        return roadmap
 
     def visualize_roadmap(self, roadmap: List[Dict]):
         """Visualize roadmap (placeholder)."""
-        # TODO: integrate with plotly or other visualization libs
-        pass
+        for entry in roadmap:
+            print(f"Year {entry['year']}: focus on {entry['focus_domain']}")

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,7 @@
+# Monitoring Tools
+
+This directory houses simple utilities used to monitor coherence metrics while other GCT services are running.
+
+Currently it contains **`coherence_monitor.py`**, a lightweight script that can be extended to track system metrics or log real‐time coherence values. The monitor can be executed directly and configured to point at different services or log files.
+
+Additional monitoring scripts can be placed here as the project grows.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Test Suite
+
+The `tests` directory contains automated tests for verifying the reference implementations in this repository. All new features should include accompanying tests when possible.
+
+To run the full suite:
+
+```bash
+pytest
+```
+
+The tests rely only on the standard library and the helper functions included in the repository, so no additional dependencies are required.

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,11 @@
+# Validation Utilities
+
+Utilities for validating GCT data and configuration files are kept in this folder. The main script, **`gct_validator.py`**, performs simple checks on datasets or model outputs to ensure they conform to expected formats.
+
+Run the validator with:
+
+```bash
+python gct_validator.py <path_to_data>
+```
+
+Contributions of additional validation scripts are welcome.


### PR DESCRIPTION
## Summary
- add documentation READMEs for docs, monitoring, tests and validation folders
- implement basic logic in playlist engine modules
- implement reference implementations in tech synergy modules
- expose package components via `__init__`

## Testing
- `pytest -q` *(fails: import file mismatch and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687859b1e3b0832180db0ba616f7ac67